### PR TITLE
Feedback to user for upcoming (dummy) listings when selected

### DIFF
--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -34,8 +34,9 @@ def play(url):
             xbmcgui.Dialog().ok(
                     'Dummy item',
                     'This item is not playable, it is used only to display '
-                    'the upcoming schedule. Playable matches will have '
-                    '"LIVE NOW" in green next to the title.')
+                    'the upcoming schedule. Please check back once the match '
+                    'has started. Playable matches will have "LIVE NOW" in '
+                    'green next to the title.')
         if 'ooyalaid' in params:
             login_token = None
             if params.get('subscription_required') == 'True':

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -30,7 +30,12 @@ def play(url):
         params = utils.get_url(url)
         v = classes.Video()
         v.parse_xbmc_url(url)
-
+        if params.get('isdummy'):
+            xbmcgui.Dialog().ok(
+                    'Dummy item',
+                    'This item is not playable, it is used only to display '
+                    'the upcoming schedule. Playable matches will have '
+                    '"LIVE NOW" in green next to the title.')
         if 'ooyalaid' in params:
             login_token = None
             if params.get('subscription_required') == 'True':

--- a/resources/lib/videos.py
+++ b/resources/lib/videos.py
@@ -52,12 +52,12 @@ def make_list(params):
 
         ok = True
         for v in videos:
-
             listitem = xbmcgui.ListItem(label=v.get_title(),
                                         thumbnailImage=v.get_thumbnail())
             listitem.setInfo('video', v.get_kodi_list_item())
             listitem.addStreamInfo('video', v.get_kodi_stream_info())
-            listitem.setProperty('IsPlayable', 'true')
+            if not v.isdummy:
+                listitem.setProperty('IsPlayable', 'true')
 
             # Build the URL for the program, including the list_info
             url = "%s?%s" % (sys.argv[0], v.make_xbmc_url())


### PR DESCRIPTION
There's a *lot* of user reports where you can see in the log they are
clicking on each and every upcoming match. This will let them know to
not expect playback to start on a future match.