### PR TITLE
Add mobile data authentication

### DIFF
--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -103,6 +103,8 @@ SIGNON_HEADERS = {'Connection': 'keep-alive',
 
 SIGNON_URL = 'https://signon.telstra.com.au/login'
 
+OLD_OFFERS_URL = 'https://api.telstra.com/v1/media-products/catalogues/media/offers?category=afl'
+
 OFFERS_URL = 'https://tapi.telstra.com/v1/media-products/catalogues/media/offers'
 
 HUB_URL = 'http://hub.telstra.com.au/sp2017-afl-app'
@@ -115,6 +117,8 @@ MEDIA_ORDER_HEADERS = {'Content-Type': 'application/json',
                        'Accept-Encoding': 'gzip, deflate',
                        'Accept-Language': 'en-AU,en-US;q=0.8',
                        'X-Requested-With': 'com.telstra.android.afl'}
+
+OLD_MEDIA_ORDER_URL = 'https://api.telstra.com/v1/media-commerce/orders'
 
 MEDIA_ORDER_URL = 'https://tapi.telstra.com/v1/media-commerce/orders'
 
@@ -143,6 +147,27 @@ SPC_HEADERS = {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,
                'User-Agent': USER_AGENT_LONG,
                'X-Requested-With': 'com.telstra.android.afl'}
 
+#Mobile Auth
+OFFER_ID = 'a482eaad-9213-419c-ace2-65b7cae73317'
+
+OAUTH_HEADERS = {'User-Agent': 'AFL(Android) / 40656',
+                 'Accept-Encoding': 'gzip'}
+
+OAUTH_URL = 'https://api.telstra.com/v1/media-commerce/oauth/token'
+
+MOBILE_ID_URL = 'http://medrx.telstra.com.au/online.php'
+
+MOBILE_CLIENT_ID = 'BDm2sYxE5twDWsM5CXAWHUPrm1ultZ9L'
+
+MOBILE_CLIENT_SECRET = 'uIGtb1DTQ0LBxe1N'
+
+MOBILE_TOKEN_PARAMS = {'client_id': MOBILE_CLIENT_ID,
+                      'client_secret': MOBILE_CLIENT_SECRET,
+                      'grant_type': 'client_credentials',
+                      'scope': 'MEDIA-PRODUCTS-API MEDIA-COMMERCE-API',
+                      'x-user-idp': 'NGP'}
+
+MOBILE_ORDER_JSON = {"offer": {"id":OFFER_ID}, "serviceType":"MSISDN"}
 
 # Categories existing on the new content system
 

--- a/resources/lib/telstra_auth.py
+++ b/resources/lib/telstra_auth.py
@@ -190,7 +190,6 @@ def get_mobile_token():
     data = config.MOBILE_TOKEN_PARAMS
     data.update({'x-user-id': mobile_userid})
     mobile_token_resp = session.post(config.OAUTH_URL, data=data)
-    utils.log(mobile_token_resp.text)
     bearer_token = json.loads(mobile_token_resp.text).get('access_token')
 
     # First check if there are any eligible services attached to the account
@@ -198,13 +197,9 @@ def get_mobile_token():
     session.headers = config.OAUTH_HEADERS
     session.headers.update(
         {'Authorization': 'Bearer {0}'.format(bearer_token)})
-    utils.log(session.headers)
     try:
         offers = session.get(config.OLD_OFFERS_URL)
     except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 401:
-            utils.log(e.response.text)
-            raise Exception()
         if e.response.status_code == 404:
             message = json.loads(e.response.text).get('userMessage')
             message += (' Please visit {0} '.format(config.HUB_URL) +

--- a/resources/lib/telstra_auth.py
+++ b/resources/lib/telstra_auth.py
@@ -230,10 +230,7 @@ def get_mobile_token():
     prog_dialog.update(60, 'Activating live pass on service')
     order_data = config.MOBILE_ORDER_JSON
     order_data.update({'serviceId': ph_no, 'pai': userid})
-    try:
-        order = session.post(config.OLD_MEDIA_ORDER_URL, json=order_data)
-    except requests.exceptions.HTTPError as e:
-        raise e
+    order = session.post(config.OLD_MEDIA_ORDER_URL, json=order_data)
 
     # check to make sure order has been placed correctly
     prog_dialog.update(80, 'Confirming activation')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,10 +9,10 @@
     <setting id="REPLAYQUALITY" type="enum" label="10009" values="270k/s - 320x180 (Lowest)|400k/s - 320x180|600k/s - 480x270|900k/s - 640x360|1.4MB/s - 720x406|2.1MB/s - 720x406|2.8MB/s - 1280x720 (Highest)" default="6" />
     <setting id="STATE" type="labelenum" label="10012" values="ACT|NSW|NT|QLD|SA|TAS|VIC|WA" default="VIC" />
     <setting id="LIVE_SUBSCRIPTION" type="bool" label="10007" default="false" />
-    <setting id="SUBSCRIPTION_TYPE" type="enum" label="10008" values="Paid (afl.com.au)|Free offer (Telstra ID)|Paid (in-app purchase)" default="1" enable="eq(-1,true)" />
+    <setting id="SUBSCRIPTION_TYPE" type="enum" label="10008" values="Paid (afl.com.au) or linked live pass|Free offer (Telstra ID)|Paid (in-app purchase)|Mobile data" default="1" enable="eq(-1,true)" />
     <setting id="LIVE_USERNAME" type="text" label="10003" default="" enable="eq(-2,true)+lt(-1,2)" />
     <setting id="LIVE_PASSWORD" type="text" label="10004" option="hidden" default="" enable="eq(-3,true)+lt(-2,2)" />
-    <setting id="IAP_TOKEN" type="text" label="10005" default="" enable="eq(-4,true)+gt(-3,1)" />
+    <setting id="IAP_TOKEN" type="text" label="10005" default="" enable="eq(-4,true)+gt(-3,1)+lt(-3,3)" />
     <setting label="10013" type="action" action="RunPlugin(plugin://plugin.video.afl-video/?action=iap_help)"/>
   </category>
   <category label="20003">


### PR DESCRIPTION
Use cases:
* Users who rely on Telstra mobile broadband for their internet access
* Telstra business mobile users who can't register a Telstra ID to their account
* Anyone else who isn't having success registering a Telstra ID for whatever reason but knows how to tether their phone's internet

Also some small changes for clarity regarding paid/linked accounts.