### PR TITLE
Fix live streams for beginning of 2019 season

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.aussieaddonscommon"/>
     <import addon="script.module.beautifulsoup4"/>
+    <import addon="script.module.drmhelper"/>
     <import addon="script.module.requests"/>
     <import addon="script.common.plugin.cache"/>
   </requires>

--- a/default.py
+++ b/default.py
@@ -67,3 +67,15 @@ if __name__ == "__main__":
             utils.user_report()
         elif params['action'] == 'iap_help':
             ooyalahelper.iap_help()
+        elif params['action'] == 'open_ia_settings':
+            try:
+                import drmhelper
+                if drmhelper.check_inputstream(drm=False):
+                    ia = drmhelper.get_addon()
+                    ia.openSettings()
+                else:
+                    utils.dialog_message(
+                        "Can't open inputstream.adaptive settings")
+            except Exception as e:
+                utils.dialog_message(
+                    "Can't open inputstream.adaptive settings")

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -20,6 +20,7 @@
     <string id="10007">AFL Live Pass Subscription</string>
     <string id="10008">Subscription Type</string>
     <string id="10013">Help finding mis-uuid token</string>
+    <string id="10014">Inputstream.adapive settings (video quality)</string>
 
     <!-- Debugging -->
     <string id="10011">Remove Stored Login Token</string>

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -65,7 +65,7 @@ SESSION_URL = 'http://api.sub.afl.com.au/cfs-premium/users/session?sessionId={0}
 EMBED_TOKEN_URL = 'https://api.afl.com.au/cfs/users/{0}/token?embedCode={1}'
 
 # URL to send our embed token and retrieve playlist
-AUTH_URL = 'http://player.ooyala.com/sas/player_api/v1/authorization/embed_code/{0}/{1}?device=html5&domain=http://www.ooyala.com&supportedFormats=m3u8'
+AUTH_URL = 'http://player.ooyala.com/sas/player_api/v1/authorization/embed_code/{0}/{1}?device=html5&domain=http://www.ooyala.com&supportedFormats=m3u8,dash'
 
 # Ooyala provider indentifier code used in contructing request uris
 PCODE = 'Zha2IxOrpV-sPLqnCop1Lz0fZ5Gi'

--- a/resources/lib/ooyalahelper.py
+++ b/resources/lib/ooyalahelper.py
@@ -203,8 +203,9 @@ def get_secure_token(secure_url, video_id):
             'Check your subscription is valid.'.format(video.get('message')))
     try:
         streams = video.get('streams')
-        ios_token = streams[0]['url']['data']
-        return base64.b64decode(ios_token)
+        stream_url = base64.b64decode(streams[0]['url']['data'])
+        widevine_url = streams[0].get('widevine_server_path')
+        return {'stream_url': stream_url, 'widevine_url': widevine_url}
     except Exception as e:
         raise AussieAddonsException(
             'Failed to get stream URL: {0}'.format(e))
@@ -282,14 +283,8 @@ def get_m3u8_playlist(video_id, live, login_token=None):
         embed_token = get_embed_token(login_token, video_id)
         auth_url = auth_url + '&embedToken=' + embed_token
 
-    secure_token_url = get_secure_token(auth_url, video_id)
-
-    if 'chunklist.m3u8' in secure_token_url:
-        return secure_token_url
-
-    m3u8_data = get_m3u8_streams(secure_token_url)
-    m3u8_playlist_url = parse_m3u8_streams(m3u8_data, live, secure_token_url)
-    return m3u8_playlist_url
+    stream_data = get_secure_token(auth_url, video_id)
+    return stream_data
 
 
 def iap_help():

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-  <category label="20001">
-    <setting id="QUALITY" type="enum" label="10001" values="Low (172k/s)|Medium (1Mb/s)|High (2Mb/s)" default="2" />
-    <setting id="TEAM" type="enum" label="10002" values="None|Adelaide|Brisbane|Carlton|Collingwood|Essendon|Fremantle|Gold Coast|Geelong|Greater Western Sydney|Hawthorn|Melbourne|North Melbourne|Port Adelaide|Richmond|St. Kilda|Sydney|West Coast|Western Bulldogs" default="0" />
-  </category>
   <category label="20002">
-    <setting id="LIVE_QUALITY" type="enum" label="10006" values="Lowest (300k/s)|Low (450k/s)|Medium (660k/s)|High (1Mb/s)|Highest (1.6Mb/s)" default="4" />
-    <setting id="REPLAYQUALITY" type="enum" label="10009" values="270k/s - 320x180 (Lowest)|400k/s - 320x180|600k/s - 480x270|900k/s - 640x360|1.4MB/s - 720x406|2.1MB/s - 720x406|2.8MB/s - 1280x720 (Highest)" default="6" />
+    <setting label="10014" type="action" action="RunPlugin(plugin://plugin.video.afl-video/?action=open_ia_settings)" option="close"/>
     <setting id="STATE" type="labelenum" label="10012" values="ACT|NSW|NT|QLD|SA|TAS|VIC|WA" default="VIC" />
     <setting id="LIVE_SUBSCRIPTION" type="bool" label="10007" default="false" />
     <setting id="SUBSCRIPTION_TYPE" type="enum" label="10008" values="Paid (afl.com.au) or linked live pass|Free offer (Telstra ID)|Paid (in-app purchase)|Mobile data" default="1" enable="eq(-1,true)" />


### PR DESCRIPTION
All live streams now appear to be DRM protected, so Kodi 18 is now the minimum required.

Inputstream.adaptive is now used whenever available for other videos.